### PR TITLE
FIX caching of promise dependencies.

### DIFF
--- a/src/injector.js
+++ b/src/injector.js
@@ -244,6 +244,9 @@ class Injector {
 
       // Once all dependencies (promises) are resolved, instantiate.
       return Promise.all(args).then(function(args) {
+        if (injector._cache.has(token)) {
+          return injector._cache.get(token);
+        }
         try {
           instance = provider.create(args);
         } catch (e) {


### PR DESCRIPTION
Promise instances from the cache were not used, unless they were leafs. If we
take as an example the following DAG: A -> B1, B2; B1 -> C;
B2 -> C; C -> D with all dependencies asynchronous, the library
would start by creating D and correctly blocking all
instantiations until it was resolved. However, when reaching the
next level, the C level, since both B1 and B2 depend on C, then
C would get created twice, i.e. the promise for C created as a
dependency for B1 would not be shared with the one created
for B2. This commit fixes this by checking if a dependency
instance already exists before instantiating it for delayed
instantiations like C. Although a unit test has been added
to validate the implementation, there are many more cases
which need to be tested to ensure a robust and complete solution.
